### PR TITLE
Update local manifest

### DIFF
--- a/substratum.xml
+++ b/substratum.xml
@@ -2,30 +2,30 @@
 <manifest>
     <!-- Get rid of Lineage repos -->
     <remove-project name="LineageOS/android_frameworks_base" />
-    <project path="frameworks/base" name="LineageOMS/android_frameworks_base" />
     <remove-project name="LineageOS/android_frameworks_native" />
-    <project path="frameworks/native" name="LineageOMS/android_frameworks_native" />
     <remove-project name="LineageOS/android_packages_apps_Contacts" />
-    <project path="packages/apps/Contacts" name="LineageOMS/android_packages_apps_Contacts" />
     <remove-project name="LineageOS/android_packages_apps_ContactsCommon" />
-    <project path="packages/apps/ContactsCommon" name="LineageOMS/android_packages_apps_ContactsCommon" />
     <remove-project name="LineageOS/android_packages_apps_Dialer" />
-    <project path="packages/apps/Dialer" name="LineageOMS/android_packages_apps_Dialer" />
     <remove-project name="LineageOS/android_packages_apps_ExactCalculator" />
-    <project path="packages/apps/ExactCalculator" name="LineageOMS/android_packages_apps_ExactCalculator" />
     <remove-project name="LineageOS/android_packages_apps_PackageInstaller" />
-    <project path="packages/apps/PackageInstaller" name="LineageOMS/android_packages_apps_PackageInstaller" />
     <remove-project name="LineageOS/android_packages_apps_PhoneCommon" />
-    <project path="packages/apps/PhoneCommon" name="LineageOMS/android_packages_apps_PhoneCommon" />
     <remove-project name="LineageOS/android_packages_apps_Settings" />
-    <project path="packages/apps/Settings" name="LineageOMS/android_packages_apps_Settings" />
-    <remove-project name="LineageOS/android_system_core" />
-    <project path="system/core" name="LineageOMS/android_system_core" />
     <remove-project name="LineageOS/android_system_sepolicy" />
-    <project path="system/sepolicy" name="LineageOMS/android_system_sepolicy" />
     <remove-project name="LineageOS/android_vendor_cm" />
+
+    <!-- Add repos for Substratum support -->
+    <project path="frameworks/base" name="LineageOMS/android_frameworks_base" />
+    <project path="frameworks/native" name="LineageOMS/android_frameworks_native" />
+    <project path="packages/apps/Contacts" name="LineageOMS/android_packages_apps_Contacts" />
+    <project path="packages/apps/ContactsCommon" name="LineageOMS/android_packages_apps_ContactsCommon" />
+    <project path="packages/apps/Dialer" name="LineageOMS/android_packages_apps_Dialer" />
+    <project path="packages/apps/ExactCalculator" name="LineageOMS/android_packages_apps_ExactCalculator" />
+    <project path="packages/apps/PackageInstaller" name="LineageOMS/android_packages_apps_PackageInstaller" />
+    <project path="packages/apps/PhoneCommon" name="LineageOMS/android_packages_apps_PhoneCommon" />
+    <project path="packages/apps/Settings" name="LineageOMS/android_packages_apps_Settings" />
+    <project path="system/sepolicy" name="LineageOMS/android_system_sepolicy" />
     <project path="vendor/cm" name="LineageOMS/android_vendor_cm" />
 
     <!-- Track ThemeInterfacer -->
-    <project path="packages/apps/ThemeInterfacer" name="substratum/interfacer" remote="github" revision="n-rootless" />
+    <project path="packages/services/ThemeInterfacer" name="substratum/interfacer" remote="github" revision="n-rootless" />
 </manifest>


### PR DESCRIPTION
This set of repos is syncable via the manifest now but some people may still want to use this

1. Clean up structure
2. system/core is no longer tracked
3. ThemeInterfacer is moved to the services folder

Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>